### PR TITLE
Minor Cmake/include changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ find_package(Threads REQUIRED)
 find_package(OpenGL REQUIRED)
 find_package(GLEW REQUIRED)
 find_package(yaml-cpp REQUIRED)
+find_package(Boost 1.58 QUIET REQUIRED COMPONENTS serialization filesystem system program_options)
 
 add_library(mujoco-nogl SHARED IMPORTED)
 add_library(mujoco SHARED IMPORTED)
@@ -41,7 +42,7 @@ elseif(UNIX)
 	  INTERFACE_INCLUDE_DIRECTORIES "$ENV{HOME}/.mujoco/mujoco200/include" )
 endif()
 
-include_directories(${OMPL_INCLUDE_DIRS})
+include_directories(${OMPL_INCLUDE_DIRS}, ${Boost_INCLUDE_DIR})
 
 add_executable(plan
     plan.cpp

--- a/plan.cpp
+++ b/plan.cpp
@@ -12,7 +12,7 @@
 #include <ompl/control/planners/kpiece/KPIECE1.h>
 #include <ompl/control/planners/pdst/PDST.h>
 #include <ompl/control/planners/sst/SST.h>
-#include "yaml-cpp/yaml.h"
+#include <yaml-cpp/yaml.h>
 
 #include "mujoco_wrapper.h"
 


### PR DESCRIPTION
An error occurred regarding a boost include file after pulling the latest version from your repo. I could fix it by adding the boost include dirs to cmake.